### PR TITLE
[signup] 회원가입 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,11 +20,16 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    testCompileOnly 'org.projectlombok:lombok'
+    testRuntimeOnly 'com.h2database:h2'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hanghaecloneproject/trade/domain/Trade.java
+++ b/src/main/java/com/hanghaecloneproject/trade/domain/Trade.java
@@ -50,7 +50,7 @@ public class Trade extends BaseEntity {
     @Column(nullable = false)
     private Long userId;
 
-    @Column(nullable = false)
+    @Column(name = "like_it", nullable = false)
     private int like;
 
     @Column(nullable = false)

--- a/src/main/java/com/hanghaecloneproject/user/controller/UserController.java
+++ b/src/main/java/com/hanghaecloneproject/user/controller/UserController.java
@@ -1,0 +1,27 @@
+package com.hanghaecloneproject.user.controller;
+
+import com.hanghaecloneproject.user.dto.SignupRequestDto;
+import com.hanghaecloneproject.user.service.UserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/user")
+@RestController
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<Void> signup(SignupRequestDto dto) {
+        userService.signup(dto);
+        return ResponseEntity.status(HttpStatus.CREATED)
+              .body(null);
+    }
+}

--- a/src/main/java/com/hanghaecloneproject/user/controller/UserExceptionHandler.java
+++ b/src/main/java/com/hanghaecloneproject/user/controller/UserExceptionHandler.java
@@ -1,0 +1,40 @@
+package com.hanghaecloneproject.user.controller;
+
+import com.hanghaecloneproject.user.error.ErrorCode;
+import com.hanghaecloneproject.user.exception.BadPasswordPatternException;
+import com.hanghaecloneproject.user.exception.DuplicateNicknameException;
+import com.hanghaecloneproject.user.exception.DuplicateUsernameException;
+import com.hanghaecloneproject.user.exception.MismatchedPasswordException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackages = "${com.hanghaecloneproject.user.controller.*}")
+public class UserExceptionHandler {
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorCode> badPasswordPatternException(BadPasswordPatternException e){
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+              .body(ErrorCode.BAD_PASSWORD_PATTERN);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorCode> duplicateNicknameException(DuplicateNicknameException e){
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+              .body(ErrorCode.DUPLICATE_NICKNAME);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorCode> duplicateUsernameException(DuplicateUsernameException e){
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+              .body(ErrorCode.DUPLICATE_USERNAME);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorCode> mismatchedPasswordException(MismatchedPasswordException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+              .body(ErrorCode.MISMATCH_PASSWORD);
+    }
+
+}

--- a/src/main/java/com/hanghaecloneproject/user/domain/User.java
+++ b/src/main/java/com/hanghaecloneproject/user/domain/User.java
@@ -10,10 +10,12 @@ import javax.persistence.Id;
 import javax.persistence.Index;
 import javax.persistence.Table;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.DynamicUpdate;
 
 @Getter
+@NoArgsConstructor
 @DynamicUpdate
 @Table(name = "users",
       indexes = {
@@ -40,6 +42,7 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String address;
 
+    @Setter
     private String profileImage;
 
     @Override
@@ -57,5 +60,12 @@ public class User extends BaseEntity {
     @Override
     public int hashCode() {
         return Objects.hash(id);
+    }
+
+    public User(String username, String password, String nickname, String address) {
+        this.username = username;
+        this.password = password;
+        this.nickname = nickname;
+        this.address = address;
     }
 }

--- a/src/main/java/com/hanghaecloneproject/user/dto/CheckNicknameDto.java
+++ b/src/main/java/com/hanghaecloneproject/user/dto/CheckNicknameDto.java
@@ -1,0 +1,11 @@
+package com.hanghaecloneproject.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CheckNicknameDto {
+
+    private String nickname;
+}

--- a/src/main/java/com/hanghaecloneproject/user/dto/CheckUsernameDto.java
+++ b/src/main/java/com/hanghaecloneproject/user/dto/CheckUsernameDto.java
@@ -1,0 +1,11 @@
+package com.hanghaecloneproject.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CheckUsernameDto {
+
+    private String username;
+}

--- a/src/main/java/com/hanghaecloneproject/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/hanghaecloneproject/user/dto/SignupRequestDto.java
@@ -1,0 +1,52 @@
+package com.hanghaecloneproject.user.dto;
+
+import com.hanghaecloneproject.user.domain.User;
+import java.io.Serializable;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Setter
+@Getter
+@NoArgsConstructor
+public class SignupRequestDto implements Serializable {
+
+    @Email private String username;
+    @NotBlank private String password;
+    @NotBlank private String passwordCheck;
+    @NotBlank private String nickname;
+    private MultipartFile profileImage;
+    private AddressDto addressDto;
+
+    public User toEntity() {
+        return new User(username, password, nickname, addressDto.toString());
+    }
+
+    @Setter
+    @Getter
+    public static class AddressDto implements Serializable {
+
+        private String circuit;
+        private String si;
+        private String gu;
+        private String dong;
+
+        @Override
+        public String toString() {
+            return circuit + " " + si + " " + gu + " " + dong;
+        }
+    }
+
+    public SignupRequestDto(String username, String password, String passwordCheck, String nickname,
+          MultipartFile profileImage, AddressDto addressDto) {
+        this.username = username;
+        this.password = password;
+        this.passwordCheck = passwordCheck;
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+        this.addressDto = addressDto;
+    }
+}

--- a/src/main/java/com/hanghaecloneproject/user/error/ErrorCode.java
+++ b/src/main/java/com/hanghaecloneproject/user/error/ErrorCode.java
@@ -1,0 +1,32 @@
+package com.hanghaecloneproject.user.error;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+
+    // 200번대는 로그인과 관련된 에러입니다.
+    NO_USER(200, "해당하는 아이디가 없습니다."),
+    BAD_CREDENTIAL(201, "잘못된 로그인 정보입니다."),
+    DISMISS_ACCOUNT(202, "회원탈퇴한 계정입니다."),
+    BAD_TOKEN_INFO(203, "다시 로그인해주세요."),
+
+    // 300번대는 회원가입과 관련된 에러입니다.
+    DUPLICATE_USERNAME(300, "중복된 아이디입니다."),
+    DUPLICATE_NICKNAME(301, "중복된 닉네임입니다."),
+    BAD_PASSWORD_PATTERN(302, "적합하지 않은 비밀번호 양식입니다."),
+    MISMATCH_PASSWORD(303, "비밀번호와 비밀번호 재입력이 일치하지 않습니다.");
+
+    // 400번대는 데이터 관련된 에러입니다.
+
+    // 500번대는 서버와 관련된 에러입니다.
+
+
+    private int code;
+    private String message;
+
+    ErrorCode(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/hanghaecloneproject/user/exception/BadPasswordPatternException.java
+++ b/src/main/java/com/hanghaecloneproject/user/exception/BadPasswordPatternException.java
@@ -1,0 +1,8 @@
+package com.hanghaecloneproject.user.exception;
+
+public class BadPasswordPatternException extends RuntimeException {
+
+    public BadPasswordPatternException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/hanghaecloneproject/user/exception/DuplicateNicknameException.java
+++ b/src/main/java/com/hanghaecloneproject/user/exception/DuplicateNicknameException.java
@@ -1,0 +1,8 @@
+package com.hanghaecloneproject.user.exception;
+
+public class DuplicateNicknameException extends RuntimeException {
+
+    public DuplicateNicknameException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/hanghaecloneproject/user/exception/DuplicateUsernameException.java
+++ b/src/main/java/com/hanghaecloneproject/user/exception/DuplicateUsernameException.java
@@ -1,0 +1,8 @@
+package com.hanghaecloneproject.user.exception;
+
+public class DuplicateUsernameException extends RuntimeException {
+
+    public DuplicateUsernameException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/hanghaecloneproject/user/exception/MismatchedPasswordException.java
+++ b/src/main/java/com/hanghaecloneproject/user/exception/MismatchedPasswordException.java
@@ -1,0 +1,8 @@
+package com.hanghaecloneproject.user.exception;
+
+public class MismatchedPasswordException extends RuntimeException {
+
+    public MismatchedPasswordException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/hanghaecloneproject/user/repository/UserRepository.java
+++ b/src/main/java/com/hanghaecloneproject/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.hanghaecloneproject.user.repository;
+
+import com.hanghaecloneproject.user.domain.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+
+    Optional<User> findByNickname(String nickname);
+}

--- a/src/main/java/com/hanghaecloneproject/user/service/UserService.java
+++ b/src/main/java/com/hanghaecloneproject/user/service/UserService.java
@@ -1,0 +1,74 @@
+package com.hanghaecloneproject.user.service;
+
+import com.hanghaecloneproject.user.domain.User;
+import com.hanghaecloneproject.user.dto.CheckNicknameDto;
+import com.hanghaecloneproject.user.dto.CheckUsernameDto;
+import com.hanghaecloneproject.user.dto.SignupRequestDto;
+import com.hanghaecloneproject.user.exception.BadPasswordPatternException;
+import com.hanghaecloneproject.user.exception.DuplicateNicknameException;
+import com.hanghaecloneproject.user.exception.DuplicateUsernameException;
+import com.hanghaecloneproject.user.exception.MismatchedPasswordException;
+import com.hanghaecloneproject.user.repository.UserRepository;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+    private static final Pattern PASSWORD_PATTERN = Pattern.compile(
+          "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d~!@#$%^&*()+|=]{8,20}$");
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public void signup(SignupRequestDto dto) {
+        validateSignupInfo(dto);
+
+        User user = dto.toEntity();
+
+        // TODO 사진 저장 로직 필요
+
+        userRepository.save(user);
+    }
+
+    private void validateSignupInfo(SignupRequestDto dto) {
+        checkDuplicateUsername(dto.getUsername());
+        checkDuplicateNickname(dto.getNickname());
+        checkMatchPassword(dto);
+        checkPasswordPattern(dto);
+    }
+
+    private void checkMatchPassword(SignupRequestDto dto) {
+        if (!dto.getPassword().equals(dto.getPasswordCheck())) {
+            throw new MismatchedPasswordException("비밀번호와 비밀번호 재확인이 일치하지 않습니다.");
+        }
+    }
+
+    private void checkPasswordPattern(SignupRequestDto dto) {
+        if (!PASSWORD_PATTERN.matcher(dto.getPassword()).matches()) {
+            throw new BadPasswordPatternException(("비밀번호는 최소 8자리에 숫자, 문자, 특수문자를 각각 1개 이상 포함해야 합니다."));
+        }
+    }
+
+    public void checkDuplicateUsername(CheckUsernameDto dto) {
+        checkDuplicateUsername(dto.getUsername());
+    }
+
+    private void checkDuplicateUsername(String username) {
+        if (userRepository.findByUsername(username).isPresent()) {
+            throw new DuplicateUsernameException("이미 존재하는 아이디입니다. 아이디: " + username);
+        }
+    }
+
+    public void checkDuplicateNickname(CheckNicknameDto dto) {
+        checkDuplicateNickname(dto.getNickname());
+    }
+
+    private void checkDuplicateNickname(String nickname) {
+        if (userRepository.findByNickname(nickname).isPresent()) {
+            throw new DuplicateNicknameException("이미 존재하는 닉네임입니다. 닉네임: " + nickname);
+        }
+    }
+}

--- a/src/main/resources/application-DEV.yaml
+++ b/src/main/resources/application-DEV.yaml
@@ -7,6 +7,9 @@ spring:
   h2:
     console:
       enabled: true
+  jpa:
+    hibernate:
+      ddl-auto: update
 
 logging:
   level:

--- a/src/test/java/com/hanghaecloneproject/user/service/UserServiceTest.java
+++ b/src/test/java/com/hanghaecloneproject/user/service/UserServiceTest.java
@@ -1,0 +1,111 @@
+package com.hanghaecloneproject.user.service;
+
+import com.hanghaecloneproject.user.dto.SignupRequestDto;
+import com.hanghaecloneproject.user.dto.SignupRequestDto.AddressDto;
+import com.hanghaecloneproject.user.exception.BadPasswordPatternException;
+import com.hanghaecloneproject.user.exception.DuplicateNicknameException;
+import com.hanghaecloneproject.user.exception.DuplicateUsernameException;
+import com.hanghaecloneproject.user.exception.MismatchedPasswordException;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+public class UserServiceTest {
+
+    private static Validator validator;
+
+    @Autowired
+    private UserService userService;
+
+    @DisplayName(value = "회원 아이디 중복이 되어서는 안된다.")
+    @Test
+    void usernameDuplicationTest() {
+        AddressDto addressDto = new AddressDto();
+        addressDto.setCircuit("경상북도");
+        SignupRequestDto dto1 = new SignupRequestDto("username@gmail.com", "password1!",
+              "password1!", "user1", null, addressDto);
+        SignupRequestDto dto2 = new SignupRequestDto("username@gmail.com", "password1!",
+              "password1!", "user2", null, addressDto);
+
+        Assertions.assertThatCode(() -> userService.signup(dto1)).doesNotThrowAnyException();
+        Assertions.assertThatThrownBy(() -> userService.signup(dto2))
+              .isInstanceOf(DuplicateUsernameException.class)
+              .hasMessageContaining("이미 존재하는 아이디");
+    }
+
+    @DisplayName(value = "아이디가 이메일 형식을 지키는가?.")
+    @Test
+    void isUsernameEmailFormTest() {
+        AddressDto addressDto = new AddressDto();
+        addressDto.setCircuit("경상북도");
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+        Set<ConstraintViolation<SignupRequestDto>> result1 = validator.validate(
+              new SignupRequestDto("username1@gmail.com", "password1!", "password1!", "user1",
+                    null, addressDto));
+        Set<ConstraintViolation<SignupRequestDto>> result2 = validator.validate(
+              new SignupRequestDto("username2", "password1!", "password1!", "user2", null,
+                    addressDto));
+
+        Assertions.assertThat(result1).isEmpty();
+        Assertions.assertThat(result2).isNotEmpty();
+    }
+
+    @DisplayName(value = "비밀번호와 비밀번호 재입력은 일치해야 한다.")
+    @Test
+    void passwordEqualsTest() {
+        AddressDto addressDto = new AddressDto();
+        addressDto.setCircuit("경상북도");
+        SignupRequestDto dto1 = new SignupRequestDto("username@gmail.com", "password1!",
+              "password1!", "user1", null, addressDto);
+        SignupRequestDto dto2 = new SignupRequestDto("username1@gmail.com", "password2!",
+              "password1!", "user2", null, addressDto);
+
+        Assertions.assertThatCode(() -> userService.signup(dto1)).doesNotThrowAnyException();
+        Assertions.assertThatThrownBy(() -> userService.signup(dto2))
+              .isInstanceOf(MismatchedPasswordException.class)
+              .hasMessageContaining("일치");
+    }
+
+    @DisplayName(value = "비밀번호는 최소 8자리에 숫자, 문자, 특수문자를 각각 1개 이상 포함해야 한다")
+    @Test
+    void passwordRegexTest() {
+        AddressDto addressDto = new AddressDto();
+        addressDto.setCircuit("경상북도");
+        SignupRequestDto dto1 = new SignupRequestDto("username1@gmail.com", "password1!",
+              "password1!", "user1", null, addressDto);
+        SignupRequestDto dto2 = new SignupRequestDto("username2@gmail.com", "pw", "pw",
+              "user2", null, addressDto);
+
+        Assertions.assertThatNoException().isThrownBy(() -> userService.signup(dto1));
+        Assertions.assertThatThrownBy(() -> userService.signup(dto2))
+              .isInstanceOf(BadPasswordPatternException.class)
+              .hasMessageContaining("8자리에 숫자, 문자, 특수문자");
+    }
+
+    @DisplayName(value = "닉네임은 중복되어서는 안된다.")
+    @Test
+    void duplicateNicknameTest() {
+        AddressDto addressDto = new AddressDto();
+        addressDto.setCircuit("경상북도");
+        SignupRequestDto dto1 = new SignupRequestDto("username1", "password1!", "password1!",
+              "user1", null, addressDto);
+        SignupRequestDto dto2 = new SignupRequestDto("username2", "password1!", "password1!",
+              "user1", null, addressDto);
+
+        Assertions.assertThatNoException().isThrownBy(() -> userService.signup(dto1));
+        Assertions.assertThatThrownBy(() -> userService.signup(dto2))
+              .isInstanceOf(DuplicateNicknameException.class)
+              .hasMessageContaining("이미 존재하는 닉네임");
+
+    }
+}


### PR DESCRIPTION
- 회원가입 제약조건 구현
    - Issue에 등록했던 회원가입을 위한 여러 제약조건들을 구현완료했습니다.
    - NotNull을 쉽게 사용하기 위해 spring-boot-starter-validation 의존성을 받았습니다.

- Exception Handling
    - 특정 상황을 명확하게 구분하기 위해 IllegalArgumentException을 구체화했습니다.
    - 일관된 Error Code를 반환하기 위해 ErrorCode.enum을 생성했습니다.
    - ExceptionHandler를 통해 단순히 Exception을 던지는 것이 아닌 클라이언트에게 Entity를 전송하게 됩니다.

- Test 코드 작성
    - 회원가입 제약조건을 테스트하기 위해 테스트코드를 작성했습니다.

- 깨알수정
    - Trade.like 의 columnname이 예약어와 곂치기 때문에 like_it으로 설정했습니다.